### PR TITLE
Turn this into a proper pip-installable package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ A python library and tool to read in and manipulate Gaussian cube files. This co
 
 Requires numpy and scipy. If you have pip, you can just run
 ```
+pip install git+https://github.com/funkymunkycool/Cube-Toolz.git
+```
+to install the ``cube_tools`` module and an executable of the same name into the currently preferred Python package installation directories.
+
+Alternatively, you can clone the repository manually and run
+```
 pip install -r requirements.txt
 ```
 to install all the requirements.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+# coding: utf-8
+from setuptools import setup
+
+setup(
+    name="Cube-Toolz",
+    version="0.3",
+    description="A python library and tool to read in and manipulate Gaussian cube files.",
+    keywords="gaussian cube file manipulation",
+    url="https://github.com/funkymunkycool/Cube-Toolz",
+    author="Tassem El-Sayed",
+    author_email="",
+    classifiers=[
+        "Environment :: Console",
+        "Topic :: Scientific/Engineering :: Chemistry",
+    ],
+    py_modules=[
+        "cube_tools",
+    ],
+    entry_points={
+        "console_scripts": [
+            "cube_tools = cube_tools:main",
+        ],
+    },
+    install_requires=[
+        "numpy>=1.12.0",
+        "scipy>=0.19.1",
+        "scikit-image>=0.14.1",
+    ]
+)


### PR DESCRIPTION
With these changes, this becomes a "proper" pip-installable package, which also means that other packages can depend on it (which is the reason I'm doing this).

Hope this is fine?